### PR TITLE
Fix shifting progress bar

### DIFF
--- a/assets/kmeans/css/kmeans.css
+++ b/assets/kmeans/css/kmeans.css
@@ -141,6 +141,7 @@ canvas {
 
 #output {
   margin-left: 5px;
+  min-width: 3ch;
 }
 
 #sigma {


### PR DESCRIPTION
The progress bar shifts when $\sigma$ value's length as string changes. This fixes it by setting a min width for the container.